### PR TITLE
feat: generate TLS certificates using cert-manager

### DIFF
--- a/charts/temporal/ci/certificates.yaml
+++ b/charts/temporal/ci/certificates.yaml
@@ -1,0 +1,90 @@
+server:
+  additionalVolumeMounts:
+    - name: tls-certs
+      mountPath: /etc/tls
+    - name: temporal-tls-certs
+      mountPath: /etc/temporal/tls
+  additionalVolumes:
+    - name: tls-certs
+      secret:
+        secretName: tls-certs
+    - name: temporal-tls-certs
+      secret:
+        secretName: temporal-tls-certs
+  config:
+    tls:
+      internode:
+        server:
+          certFile: "/etc/temporal/tls/tls.crt"
+          keyFile: "/etc/temporal/tls/tls.key"
+          requireClientAuth: true
+          clientCaFiles:
+            - "/etc/temporal/tls/ca.crt"
+        client:
+          serverName: ""
+          rootCaFiles:
+            - "/etc/temporal/tls/ca.crt"
+      frontend:
+        server:
+          certFile: "/etc/temporal/tls/tls.crt"
+          keyFile: "/etc/temporal/tls/tls.key"
+          requireClientAuth: false
+        client:
+          serverName: ""
+          rootCaFiles:
+            - "/etc/temporal/tls/ca.crt"
+web:
+  additionalVolumeMounts:
+    - name: tls-certs
+      mountPath: /etc/tls
+    - name: temporal-tls-certs
+      mountPath: /etc/temporal/tls
+  additionalVolumes:
+    - name: tls-certs
+      secret:
+        secretName: tls-certs
+    - name: temporal-tls-certs
+      secret:
+        secretName: temporal-tls-certs
+  additionalEnv:
+    - name: TEMPORAL_TLS_SERVER_NAME
+      value: ""
+    - name: TEMPORAL_TLS_CA
+      value: /etc/temporal/tls/ca.crt
+    - name: TEMPORAL_TLS_CERT
+      value: /etc/temporal/tls/tls.crt
+    - name: TEMPORAL_TLS_KEY
+      value: /etc/temporal/tls/tls.key
+frontend:
+  service:
+    enabled: true
+  ingress:
+    enabled: true
+    className: ""
+    hosts:
+      - ""
+additionalSecrets:
+  - name: tls-certs
+    value:
+      tls.crt: |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+      tls.key: |
+        -----BEGIN EC PRIVATE KEY-----
+        -----END EC PRIVATE KEY-----
+certificates:
+  enabled: false
+  issuer:
+    name: temporal-issuer
+    secretName: tls-certs
+  certificate:
+    name: temporal-cert
+    isCA: false
+    secret:
+      name: temporal-tls-certs
+    privateKey:
+      algorithm: RSA
+      size: 2048
+      rotationPolicy: Always
+    annotations:
+      argocd.argoproj.io/hook: PreSync

--- a/charts/temporal/templates/certificates.yaml
+++ b/charts/temporal/templates/certificates.yaml
@@ -1,0 +1,27 @@
+---
+{{- if .Values.certificates.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certificates.issuer.name }}
+spec:
+  ca:
+    secretName: {{ .Values.certificates.issuer.secretName }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certificates.certificate.name }}
+spec:
+  dnsNames:
+    - {{ index .Values.server.frontend.ingress.hosts 0 }}
+  commonName: {{ index .Values.server.frontend.ingress.hosts 0 }}
+  isCA: {{ .Values.certificates.certificate.isCA }}
+  issuerRef:
+    kind: Issuer
+    name: {{ .Values.certificates.issuer.name }}
+  secretName: {{ .Values.certificates.certificate.secret.name }}
+  privateKey:
+    algorithm: {{ .Values.certificates.certificate.privateKey.algorithm }}
+    size: {{ .Values.certificates.certificate.privateKey.size }}
+    rotationPolicy: {{ .Values.certificates.certificate.privateKey.rotationPolicy }}

--- a/charts/temporal/templates/secret.yaml
+++ b/charts/temporal/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.additionalSecrets }}
+{{- range .Values.additionalSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .name }}"
+data:
+{{- range $key, $val := .value }}
+  {{ $key }}: {{ $val | b64enc | nindent 4 }}
+{{- end }}
+type: Opaque
+{{- end }}
+{{- end }}

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -566,3 +566,4 @@ additionalSecrets: []
   #     tls.key: |
   #       -----BEGIN EC PRIVATE KEY-----
   #       -----END EC PRIVATE KEY-----
+.

--- a/charts/temporal/values.yaml
+++ b/charts/temporal/values.yaml
@@ -541,3 +541,28 @@ cassandra:
     type: ClusterIP
 mysql:
   enabled: false
+
+certificates:
+  enabled: false
+  issuer:
+    name: temporal-issuer
+    secretName: tls-certs
+  certificate:
+    name: temporal-cert
+    isCA: false
+    secret:
+      name: temporal-tls-certs
+    privateKey:
+      algorithm: RSA
+      size: 2048
+      rotationPolicy: Always
+
+additionalSecrets: []
+  # - name: tls-certs
+  #   value:
+  #     tls.crt: |
+  #       -----BEGIN CERTIFICATE-----
+  #       -----END CERTIFICATE-----
+  #     tls.key: |
+  #       -----BEGIN EC PRIVATE KEY-----
+  #       -----END EC PRIVATE KEY-----


### PR DESCRIPTION
What was changed
Add certificates.yaml + secret.yaml to templates
Add README.md

Why?
generate certificates using cert-manager

How was this tested
Deployed [cert-manager helm-chart](https://github.com/cert-manager/cert-manager/tree/master/deploy)
Deployed temporal helm chart, 0.57.0, using temporal/charts/temporal/tests/certificates.yaml as values.yaml, with my own tls.crt + tls.key
Cert-manager will:

Use the temporal-issuer (which refers to the CA).
Ask the CA (from the tls-certs secret) to sign a new certificate.
Create the temporal-tls-certs secret in the same namespace — this secret will contain:
tls.crt: the signed certificate
tls.key: the private key
Optionally, ca.crt: the CA certificate (if configured)
➜  ~ kubectl get secret -n temporal

NAME                          TYPE                   DATA       AGE
temporal-tls-certs            kubernetes.io/tls      3          3h38m
tls-certs                     Opaque                 2          153m


➜  ~ kubectl get certificate  -n temporal

NAME                READY          SECRET                       AGE
temporal-cert       True           temporal-tls-certs           5h35m


➜  ~ kubectl get certificaterequests  -n temporal-data

NAME              APPROVED   DENIED   READY   ISSUER            REQUESTER                                                                      AGE
temporal-cert-1   True                True    temporal-issuer   system:serviceaccount:cert-manager:test-cert-manager  5h